### PR TITLE
Run build-hash instead of build in Github Actions

### DIFF
--- a/.github/workflows/npm-build-and-deploy-develop.yml
+++ b/.github/workflows/npm-build-and-deploy-develop.yml
@@ -20,7 +20,7 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
             - run: npm ci
-            - run: npm run build
+            - run: npm run build-hash
             - name: Create CNAME file
               uses: finnp/create-file-action@master
               env:


### PR DESCRIPTION
to fix the deposit-withdraw page missing issue (https://github.com/bitshares/bitshares-ui/issues/3302#issuecomment-766249950)

