### PR TITLE
Use totalForSale for market depth in order book

### DIFF
--- a/app/components/Exchange/OrderBook.jsx
+++ b/app/components/Exchange/OrderBook.jsx
@@ -779,10 +779,10 @@ class OrderBook extends React.Component {
                     );
                 });
             } else {
-                let maxBid = tempBids.length ? tempBids[tempBids.length - 1].totalToReceive().getAmount() : 0;
+                let maxBid = tempBids.length ? tempBids[tempBids.length - 1].totalForSale().getAmount() : 0;
                 
                 bidRows = tempBids.map((order, index) => {
-                    const value = order.totalToReceive().getAmount();
+                    const value = order.totalForSale().getAmount();
                     const percentage = Math.ceil(value * 100 / maxBid);
                     return horizontal ? (
                         <OrderBookRowHorizontal
@@ -818,10 +818,10 @@ class OrderBook extends React.Component {
                     );
                 });
 
-                let maxAsk = tempAsks.length ? tempAsks[tempAsks.length - 1].totalToReceive().getAmount() : 0;
+                let maxAsk = tempAsks.length ? tempAsks[tempAsks.length - 1].totalForSale().getAmount() : 0;
                 
                 askRows = tempAsks.map((order, index) => {
-                    const value = order.totalToReceive().getAmount();
+                    const value = order.totalForSale().getAmount();
                     const percentage = Math.ceil(value * 100 / maxAsk);
                     return horizontal ? (
                         <OrderBookRowHorizontal


### PR DESCRIPTION
For better view when there are orders with extreme large amounts on the order book.

For testing https://github.com/bitshares/bitshares-ui/pull/3634:
https://develop.bitshares.org/#/market/BTS_XBTSX.USDT
https://develop.bitshares.org/#/market/BTS_USD
https://develop.bitshares.org/#/market/BTS_CNY
vs
https://pr.bts.mobi/#/market/BTS_XBTSX.USDT
https://pr.bts.mobi/#/market/BTS_USD
https://pr.bts.mobi/#/market/BTS_CNY
